### PR TITLE
Preserve local npmrc file

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,8 +24,6 @@ const upd = combined.split('\n')
   .concat('package-lock=true')
   .join('\n')
 
-console.log(upd)
-
 fs.writeFileSync('.npmrc', upd)
 
 try {

--- a/index.js
+++ b/index.js
@@ -8,10 +8,23 @@ const { spawnSync } = require('child_process')
 const npmrc = path.join(os.homedir(), '.npmrc')
 const npm = fs.readFileSync(npmrc, 'utf-8')
 
-const upd = npm.split('\n')
+let localnpmrc = ''
+let hasLocalNpmrc = false
+try {
+  localnpmrc = fs.readFileSync('.npmrc', 'utf-8')
+  hasLocalNpmrc = true
+} catch (e) {
+  // nothing
+}
+
+const combined = [npm, localnpmrc].join('\n')
+
+const upd = combined.split('\n')
   .filter(l => l.indexOf('package-lock') === -1)
   .concat('package-lock=true')
   .join('\n')
+
+console.log(upd)
 
 fs.writeFileSync('.npmrc', upd)
 
@@ -21,4 +34,9 @@ try {
   console.error(err.message)
 }
 
-fs.unlinkSync('.npmrc')
+if (hasLocalNpmrc) {
+  fs.writeFileSync('.npmrc', localnpmrc)
+} else {
+  fs.unlinkSync('.npmrc')
+}
+


### PR DESCRIPTION
When using a local .npmrc file, preserve the contents. Useful when using GitHub private registry. 